### PR TITLE
Set commentstring correctly

### DIFF
--- a/ftplugin/applescript.vim
+++ b/ftplugin/applescript.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=--\ %s

--- a/ftplugin/applescript.vim
+++ b/ftplugin/applescript.vim
@@ -1,1 +1,17 @@
+" Vim filetype plugin file
+" Language:             AppleScript
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:undo_ftplugin = "setlocal commentstring<"
+
 setlocal commentstring=--\ %s
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
Current implementation doesn't set `commentstring`, so auto-commenting plugins use the default (c-style).